### PR TITLE
Increasing timeout.repo.read.seconds to 3600

### DIFF
--- a/templates/sag-cc-tuneup/template.yaml
+++ b/templates/sag-cc-tuneup/template.yaml
@@ -27,7 +27,7 @@ environments:
     # Read from Platform Manager timeout (seconds) 
     timeout.spm.read.seconds: 900
     # Read product and fix repositories timeout (milliseconds)
-    timeout.repo.read.seconds: 5
+    timeout.repo.read.seconds: 3600
     
     # Default job timeout (seconds)
     timeout.job.seconds: 4800


### PR DESCRIPTION
Done to resolve issue in the following SWAT discussion: RE: Error in CC 10.3 - Cannot initialize the repository properly!